### PR TITLE
cb-51: Create layout for search history display

### DIFF
--- a/app/js/components/page/pageComponent.jsx
+++ b/app/js/components/page/pageComponent.jsx
@@ -5,13 +5,32 @@ import ActionsComponent from '../actionsComponent';
 import './pageComponent.css';
 
 class PageComponent extends Component{
-    componentDidMount(){}
+    constructor(props) {
+        super(props);
+        this.state = {
+            history: []
+        }
+        this.addToHistory = this.addToHistory.bind(this);
+    }
+
+    componentDidMount() {
+        const currentHistory = JSON.parse(window.sessionStorage.getItem('openmrsHistory'));
+        if(currentHistory) {
+            this.setState({history: currentHistory});
+        }
+    }
+
+    addToHistory(description, total, parameters) {
+        const newHistory = [...this.state.history, {description, total, parameters}];
+        window.sessionStorage.setItem('openmrsHistory', JSON.stringify(newHistory));
+        this.setState({history: newHistory});
+    }
 
     render(){
         return(
             <div id="body-wrapper" className="page-wrapper">
-                <TabsComponent />
-                <SearchHistoryComponent />
+                <TabsComponent addToHistory={this.addToHistory} />
+                <SearchHistoryComponent history={this.state.history} />
                 <ActionsComponent />
             </div>
         );

--- a/app/js/components/searchHistory/searchHistory.css
+++ b/app/js/components/searchHistory/searchHistory.css
@@ -24,11 +24,21 @@
 
 .result-window {
     padding: 10px;
-    color: #ff6300;
     border-color: #000;
     border-width: 1px;
     border-style: solid;
     margin-top: 20px;
     margin-bottom: 20px;
-    text-decoration: underline;
+}
+
+.view-result, .save {
+    cursor: pointer;
+}
+.save {
+    color: #000;
+    font-size: 20px;
+}
+
+.view-result {
+    color: #363463;
 }

--- a/app/js/components/searchHistory/searchHistoryComponent.jsx
+++ b/app/js/components/searchHistory/searchHistoryComponent.jsx
@@ -1,30 +1,46 @@
 import React, {Component} from 'react';
+import shortId from 'shortid'
 
 import './searchHistory.css';
 
-export default class SearchHistoryComponent extends Component{
-    componentDidMount(){}
+class SearchHistoryComponent extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            searchHistory : []
+        };
+    }
+
+    componentWillReceiveProps(nextProps) {
+        this.setState({searchHistory: nextProps.history});
+    }
+
     render(){
         return (
             <div className="col-sm-12 section">
                 <h3>Search History</h3>
-                <div className="history-window">
-                    <span>No Search History</span>
-                </div>
-                <form className="form-horizontal">
-                    <div className="form-group">
-                        <label className="col-sm-3 control-label">Display which cohort</label>
-                        <div className="col-sm-5">
-                            <select className="form-control" name="cohort">
-                                <option value="all">Results of last search</option>
-                            </select>
-                        </div>
-                    </div>
-                </form>
                 <div className="result-window">
-                    <span>No Results</span>
+                    {
+                        (this.state.searchHistory.length > 0) ?
+                            <table className="table table-hover">
+                                <tbody>
+                                    {
+                                        this.state.searchHistory.map((eachResult) =>
+                                            <tr key={shortId.generate()}>
+                                                <td>{eachResult.description}</td>
+                                                <td>{eachResult.total +' result(s)'}</td>
+                                                <td><span className="glyphicon glyphicon-glyphicon glyphicon-floppy-disk save" aria-hidden="true"></span></td>
+                                                <td className="view-result">View</td>
+                                            </tr>
+                                        )
+                                    }
+                                </tbody>
+                            </table>
+                            : <p className="text-center">No search History</p>
+                    }
                 </div>
             </div>
         );
     }
 }
+export default SearchHistoryComponent;

--- a/app/js/components/tabs/tabContentComponent.jsx
+++ b/app/js/components/tabs/tabContentComponent.jsx
@@ -3,7 +3,7 @@ import React, { PropTypes } from 'react';
 const TabContentComponent = (props) => {
      return (
             <div className="tab-content">
-                {props.drawComponent(props.tabs, props.fetchData, props.search)}
+                {props.drawComponent(props.tabs, props.fetchData, props.search, props.addToHistory)}
             </div>
         );
 };

--- a/app/js/components/tabs/tabcomponents/patientComponent.jsx
+++ b/app/js/components/tabs/tabcomponents/patientComponent.jsx
@@ -77,6 +77,7 @@ class PatientComponent extends Component {
     }
 
     performSearch(searchParameters) {
+        const theParameter = Object.assign({}, searchParameters);
         this.props.search(searchParameters).then(results => {
             const allPatients = results.rows;
             const pagePatientInfo = this.getPatientDetailsPromises(allPatients, this.state.currentPage);
@@ -84,7 +85,10 @@ class PatientComponent extends Component {
                 toDisplay: pagePatientInfo,
                 searchResults: allPatients,
                 description: results.searchDescription,
-                totalPage: Math.ceil(allPatients.length/this.state.perPage)});
+                totalPage: Math.ceil(allPatients.length/this.state.perPage)
+            });
+            // adds the current search to search history
+            this.props.addToHistory(results.searchDescription, allPatients.length, theParameter);
         });
     }
     

--- a/app/js/components/tabs/tabsComponent.jsx
+++ b/app/js/components/tabs/tabsComponent.jsx
@@ -60,11 +60,11 @@ class TabsComponent extends Component {
         return getData;
     }
 
-    drawComponent(tabs, fetchData, search) {
+    drawComponent(tabs, fetchData, search, addToHistory) {
         return tabs.map((tab,index) => {
             return(
                 <div id={tab.divId} key={index} className={'tab-pane ' + (tab.active ? 'active' : '')}>
-                    <tab.component fetchData={fetchData} search={search}/>
+                    <tab.component fetchData={fetchData} search={search} addToHistory={addToHistory} />
                 </div>
             );
         });
@@ -74,7 +74,13 @@ class TabsComponent extends Component {
         return (
             <div className="col-sm-12 section">
                 <TabBarComponent tabs={this.state.tabs} drawTabHeader={this.drawTabHeader} />
-                <TabContentComponent tabs={this.state.tabs} search={this.search} drawComponent={this.drawComponent} fetchData={this.fetchData} />
+                <TabContentComponent
+                    tabs={this.state.tabs}
+                    search={this.search}
+                    drawComponent={this.drawComponent}
+                    fetchData={this.fetchData}
+                    addToHistory={this.props.addToHistory}
+                />
             </div>
         );
     }


### PR DESCRIPTION
# JIRA TICKET NAME:
[CB-51](https://issues.openmrs.org/browse/CB-51?) Create layout for search history display
## SUMMARY:
The search histories are populated in a table just below the tabs where the search actually takes place. Each time a search is made, the result (descriptive label, total results e.t.c) are appended to the search history table. The history is also saved in the sessionStorage so that if the user needs to reload the page he/she can still see searches made. They are not stored in localStorage because we don't want to bore users with a long list of old history
<img width="1042" alt="screen shot 2017-04-08 at 9 12 59 am" src="https://cloud.githubusercontent.com/assets/17332992/24827162/61ce24c8-1c3d-11e7-8998-12bfb5b94e21.png">
