### PR TITLE
CB-69: Add description field to composition search

### DIFF
--- a/app/js/components/tabs/tabcomponents/compositionComponent.jsx
+++ b/app/js/components/tabs/tabcomponents/compositionComponent.jsx
@@ -18,6 +18,7 @@ class CompositionComponent extends Component {
     performComposition(event) {
         event.preventDefault();
         const search = document.getElementById('composition-search-query').value;
+        const description = document.getElementById('composition-description').value;
         const jsonHelper = new JSONHelper;
         let compositionQuery = {};
         compositionQuery.type = "org.openmrs.module.reporting.dataset.definition.PatientDataSetDefinition";
@@ -39,7 +40,7 @@ class CompositionComponent extends Component {
                 compositionQuery.customRowFilterCombination += ` ${eachToken} `;
             }
         });
-        this.performSearch({label: search, query: compositionQuery});
+        this.performSearch({label: description, query: compositionQuery});
     }
 
     performSearch(compositionQuery) {
@@ -77,6 +78,11 @@ class CompositionComponent extends Component {
                     <div className="form-group">
                         <div className="col-sm-12">
                             <input id="composition-search-query" type="text" className="form-control" placeholder="Enter search query. . ." />
+                        </div>
+                    </div>
+                    <div className="form-group">
+                        <div className="col-sm-12">
+                            <input id="composition-description" type="text" className="form-control" placeholder="Enter a description" />
                         </div>
                     </div>
                     <div className="form-group">

--- a/tests/tabs/compositionComponent.test.jsx
+++ b/tests/tabs/compositionComponent.test.jsx
@@ -13,10 +13,10 @@ describe('<CompositionComponent />', ()=>{
 
     it('should contain the correct HTML elements', ()=>{
         const wrapper = shallow(<CompositionComponent />);
-        expect(wrapper.find("div")).to.have.length(6);
+        expect(wrapper.find("div")).to.have.length(8);
         expect(wrapper.find("p")).to.have.length(1);
         expect(wrapper.find("form")).to.have.length(1);
-        expect(wrapper.find("input")).to.have.length(1);
+        expect(wrapper.find("input")).to.have.length(2);
         expect(wrapper.find("button")).to.have.length(1);
     });
 });


### PR DESCRIPTION
# JIRA TICKET NAME:
CB-69: [Add description field to composition search](https://issues.openmrs.org/browse/CB-69)

## SUMMARY:
Adds a description field to the composition search so that users can specify the description they want for their composition.