### PR TITLE
CB-67: Update Encounter Search to make use of all fields in search

### DIFF
--- a/app/js/helpers/jsonHelper.js
+++ b/app/js/helpers/jsonHelper.js
@@ -153,11 +153,6 @@ export class JSONHelper {
         return ` ${searchParameters[key][0].value} as ${searchParameters[key][1].value}`;
       case 'diedDuringPeriod':
         return searchParameters[key][0].livingStatus === 'alive' ? ' Alive' : ' Dead';
-      case 'encounterSearchAdvanced': {
-        let subLabel = ` encounter(s)`;
-        subLabel += this.getEncounterLabel(searchParameters[key]);
-        return subLabel;
-      }
       default :
         return '';
     }
@@ -165,30 +160,5 @@ export class JSONHelper {
 
   getGenderName(gender) {
     return gender.charAt(0).toUpperCase()+gender.slice(1, gender.length-1); 
-  }
-
-  getEncounterLabel(parameters) {
-    let label = '';
-    parameters.forEach(aParameter => {
-      if(aParameter.value != '') {
-        switch(aParameter.name) {
-          case 'encounterTypes':
-            label += ` of type(s) ${aParameter.value}`; break;
-          case 'locations':
-            label += ` at ${aParameter.value[0]}`; break;
-          case 'forms':
-            label += ` from ${aParameter.value[0]} form`; break;
-          case 'atLeast':
-            label += ` at least ${aParameter.value} ${aParameter.value > 1 ? 'times' : 'time'}`; break;
-          case 'atMost':
-            label += ` at most ${aParameter.value} ${aParameter.value > 1 ? 'times' : 'time'}`; break;
-          case 'startDate':
-            label += ` from ${aParameter.value}`; break;
-          case 'endDate':
-            label += ` to ${aParameter.value}`; break;
-        }
-      }
-    });
-    return label;
   }
 }


### PR DESCRIPTION
# JIRA TICKET NAME:
[CB-67: Update Encounter Search to make use of all fields in search](https://issues.openmrs.org/browse/CB-67)
## SUMMARY:
Background: At the moment, the encounter search is working, but the form field and upto this many field is not used in the search. This may have a lot to do with the encountercohortdefinition in the reporting module
When a user selects form on the encounter tab search, it should show patients with encounters in that form.
When a user enters a number in the up to maximum field, it should show patients who have not encounters more than the number specified
Fix the field (input & select) ids because of the PR raised here https://github.com/openmrs/openmrs-module-reporting/pull/145