### PR TITLE
CB-84: Remove Unnecessary space in search tabs buttons.

### DIFF
--- a/app/js/components/tabs/tabs.css
+++ b/app/js/components/tabs/tabs.css
@@ -18,6 +18,8 @@ ul.nav-tabs>li {
 }
 
 .nav-tabs>li>a {
+    border-width: 0;
+    margin: 0px;
     border: none;
     color: #363463;
     -moz-border-radius: 3px;


### PR DESCRIPTION
# JIRA TICKET NAME: CB-84

## SUMMARY:
Remove unnecessary whitespace between and above search tabs.
https://issues.openmrs.org/browse/CB-84