### PR TITLE
CB-142: Fix `toastr` not defined error

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
     "tests"
   ],
   "dependencies": {
-    "bootstrap": "3.3.7"
+    "bootstrap": "3.3.7",
+    "toastr": "2.1.3"
   }
 }


### PR DESCRIPTION
# JIRA TICKET NAME:
CB-142: [Fix toastr not installed error](https://issues.openmrs.org/browse/CB-142)

## SUMMARY:
This PR fixes the `toastr` not defined error.