### PR TITLE
CB-138: Result fetching does not work properly for the Concept search.

### DIFF
--- a/app/js/components/tabs/tabcomponents/conceptComponent.jsx
+++ b/app/js/components/tabs/tabcomponents/conceptComponent.jsx
@@ -107,6 +107,7 @@ class ConceptComponent extends Component {
               options={this.state.conceptsResults}
               placeholder="search concepts"
               onChange={this.setConcept}
+              useCache={false}
               paginate
             />
           </div>


### PR DESCRIPTION
# JIRA TICKET NAME:
CB-138 [Click here to view issue on JIRA](https://issues.openmrs.org/browse/CB-138)
## SUMMARY:
- The AsyncTypeahead was malfunctioning as it was using cached queries to retrieve our data. Thus  the querying produced inconsistent results. Leveraging on its `useCache` property and setting it to false fixes the result's inconsistency. 