### PR TITLE
[chore] Capture error if one uses the incorrect dataset

### DIFF
--- a/app/js/components/tabs/tabsComponent.jsx
+++ b/app/js/components/tabs/tabsComponent.jsx
@@ -15,6 +15,7 @@ import TabBarComponent from './tabBarComponent';
 import TabContentComponent from './tabContentComponent';
 import { ApiHelper } from '../../helpers/apiHelper';
 import { JSONHelper } from '../../helpers/jsonHelper';
+import utility from '../../utility';
 
 import './tabs.css';
 
@@ -50,11 +51,23 @@ class TabsComponent extends Component {
     const searchResult = new Promise(function(resolve, reject) {
       apiHelper.post('reportingrest/adhocquery?v=full', queryDetails.query).then(response => {
         response.json().then(data => {
+          if (data.error){
+            if(data.error.message ===  "[null]" ){
+              utility.notifications('error', 'Search error, check the server log for details');
+              return data.error;
+            }
+            else{
+            utility.notifications('error', 'So far we only support ad hoc queries of PatientDataSetDefinition');
+            return data.error;
+            }
+          }
+          else{
           data.searchDescription = description || queryDetails.label;
           data.query = queryDetails.query;
           getHistory(data, data.searchDescription);
           resolve(data);
-        });
+          }
+        }).catch(error => error);
       });
     });
     return searchResult;


### PR DESCRIPTION
# JIRA TICKET NAME:
[CB-145](https://issues.openmrs.org/browse/CB-145)
Error handling if one uses a dataset which is not compatible with the current cohort builder.

## SUMMARY:
When one uses a dataset that is not compatible with the "new" cohort-builder and one press the search button, we should give an elaborate message as to why the app is not functioning as expected. This talk [here](https://talk.openmrs.org/t/error-building-owa-cohort-builder-app/12740/9) led to the creation of this ticket.

