### PR TITLE
[CB-163] Form resets when the Search button is clicked

### DIFF
--- a/app/js/cohortbuilder.jsx
+++ b/app/js/cohortbuilder.jsx
@@ -11,6 +11,7 @@
 import React from 'react';
 import {render} from 'react-dom';
 import {Router, Route, hashHistory} from 'react-router';
+
 import App from './components/App';
 
 import 'react-select/dist/react-select.css';

--- a/app/js/components/App.jsx
+++ b/app/js/components/App.jsx
@@ -36,7 +36,7 @@ class App extends Component {
   }
 
   setHistory(data) {
-    this.setState({ 
+    this.setState({
       history : data.rows || data.patients
     });
   }
@@ -53,15 +53,16 @@ class App extends Component {
     const { display, table, history, description , getHistory, setHistory } = this.state;
     return (
       <div>
-        <div 
+        <div
           id="tabbed-cohort" style={{display}}>
           <Header/>
           <BreadCrumbComponent/>
           <PageComponent getHistory = {this.getHistory} setHistory = {this.setHistory} />
         </div>
-        <div id="body-wrapper" 
+        <div
+          id="body-wrapper"
           style={{display :table}}>
-          <div id="displayTable"  className="col-md-12 section">
+          <div id="displayTable" className="col-md-12 section">
               <CohortTable
                 toDisplay = {history}
                 description = {description}

--- a/app/js/components/tabs/tabcomponents/observationComponent.jsx
+++ b/app/js/components/tabs/tabcomponents/observationComponent.jsx
@@ -132,32 +132,32 @@ export default class ObsFilter extends React.Component {
   // NM(numeric) datatype
   firstFieldNumeric(){
     return(
-            <div className="form-group" >
-                <label className="col-sm-3 control-label">Which observations?</label>
-                <div className="col-sm-6">
-                    <select 
-                        className="form-control"
-                        value={this.state.timeModifier}
-                        defaultValue="ANY"
-                        name="timeModifier"
-                        onChange={this.handleFormChange}>
-                        <option value="ANY">Any</option>
-                        <option value="NO">None</option>
-                        <option value="FIRST">Earliest</option>
-                        <option value="LAST">Most Recent</option>
-                        <option value="MIN">Lowest</option>
-                        <option value="MAX">Highest</option>
-                        <option value="AVG">Average</option>
-                    </select>
-                </div>
-            </div>
+      <div className="form-group">
+        <label className="col-sm-3 control-label">Which observations?</label>
+        <div className="col-sm-6">
+          <select 
+            className="form-control"
+            value={this.state.timeModifier}
+            defaultValue="ANY"
+            name="timeModifier"
+            onChange={this.handleFormChange}>
+            <option value="ANY">Any</option>
+            <option value="NO">None</option>
+            <option value="FIRST">Earliest</option>
+            <option value="LAST">Most Recent</option>
+            <option value="MIN">Lowest</option>
+            <option value="MAX">Highest</option>
+            <option value="AVG">Average</option>
+          </select>
+        </div>
+      </div>
     );
   }
 
   // DT(Date) OR TS(DateTime)
   timeModifierDateOrDateTime() {
     return (
-      <div className="form-group" >
+      <div className="form-group">
         <label className="col-sm-4 control-label"> Which observations? </label>
         <div className="col-sm-4">
           <select className="form-control" 
@@ -180,82 +180,82 @@ export default class ObsFilter extends React.Component {
   // ST(Text)  OR CWE(Coded) OR BIT(Boolean)
   timeModifierSCB() {
     return (
-            <div className="form-group" >
-                    <label className="col-sm-4 control-label"> Which observations? </label>
-                    <div className="col-sm-4">
-                        <select className="form-control" 
-                            name="timeModifier"
-                            defaultValue="ANY"
-                            onChange={this.handleFormChange}
-                            value={this.state.timeModifier}>
-                            <option value="">select an observation</option>
-                            <option value="ANY">Any</option>
-                            <option value="NO">None</option>
-                            <option value="FIRST">Earliest</option>
-                            <option value="LAST">Most Recent</option>
-                        </select>
-                    </div>
-            </div>
+      <div className="form-group">
+        <label className="col-sm-4 control-label"> Which observations? </label>
+        <div className="col-sm-4">
+          <select className="form-control" 
+            name="timeModifier"
+            defaultValue="ANY"
+            onChange={this.handleFormChange}
+            value={this.state.timeModifier}>
+            <option value="">select an observation</option>
+            <option value="ANY">Any</option>
+            <option value="NO">None</option>
+            <option value="FIRST">Earliest</option>
+            <option value="LAST">Most Recent</option>
+          </select>
+        </div>
+      </div>
     );
   }
 
   // NM(numeric) datatype
   secondFieldNumeric() {
     return(
-            <div  className="form-group" >
-                <label  className="col-sm-3 control-label">What values?</label>
-                <div className="col-sm-2">
-                    <select className="form-control" name="operator" 
-                        onChange={this.handleFormChange}
-                        value={this.state.operator}>
-                        <option value="LESS_THAN">&lt;</option>
-                        <option value="LESS_EQUAL">&lt;=</option>
-                        <option value="EQUAL">=</option>
-                        <option value="GREATER_EQUAL">&gt;=</option>
-                        <option value="GREATER_THAN">&gt;</option>
-                    </select>
-                </div>
-                <div className="col-sm-4">
-                    <input type="number"
-                        className="form-control" 
-                        placeholder={`Enter a value ${this.props.concept.units}`}
-                        value={this.state.modifier}
-                        name="modifier"
-                        ref={this.setRef}
-                        onChange={this.handleFormChange} />
-                </div>
-            </div>
+      <div  className="form-group">
+        <label  className="col-sm-3 control-label">What values?</label>
+        <div className="col-sm-2">
+          <select className="form-control" name="operator" 
+            onChange={this.handleFormChange}
+            value={this.state.operator}>
+            <option value="LESS_THAN">&lt;</option>
+            <option value="LESS_EQUAL">&lt;=</option>
+            <option value="EQUAL">=</option>
+            <option value="GREATER_EQUAL">&gt;=</option>
+            <option value="GREATER_THAN">&gt;</option>
+          </select>
+        </div>
+        <div className="col-sm-4">
+          <input type="number"
+            className="form-control" 
+            placeholder={`Enter a value ${this.props.concept.units}`}
+            value={this.state.modifier}
+            name="modifier"
+            ref={this.setRef}
+            onChange={this.handleFormChange} />
+        </div>
+      </div>
     );
   }
 
   // DT(Date) OR TS(DateTime)
   modifierDateOrDateTime() {
     return (
-            <div className="form-group col-sm-12" >
-                <label  className="col-sm-4 control-label">(optional) (valueDatetime)?</label>
-                <div className="col-sm-4">
-                    <select className="form-control" name="operator" id="operator"
-                        value={this.state.operator} 
-                        onChange={this.handleFormChange}>
-                        <option value="">select a range</option>
-                        <option value="LESS_THAN">before</option>
-                        <option value="LESS_EQUAL">on or before</option>
-                        <option value="EQUAL">on</option>
-                        <option value="GREATER_EQUAL">on or after</option>
-                        <option value="GREATER_THAN">after</option>
-                    </select>
-                </div>
-                <div className="col-sm-4">
-                    <DatePicker
-                            className="form-control"
-                            id="modifier"
-                            dateFormat="DD-MM-YYYY"
-                            value={this.state.modifier}
-                            name="modifier"
-                            onChange={this.handleDateChange('modifier')}
-                        />
-                </div>
-            </div>
+      <div className="form-group col-sm-12">
+        <label  className="col-sm-4 control-label">(optional) (valueDatetime)?</label>
+        <div className="col-sm-4">
+          <select className="form-control" name="operator" id="operator"
+            value={this.state.operator} 
+            onChange={this.handleFormChange}>
+            <option value="">select a range</option>
+            <option value="LESS_THAN">before</option>
+            <option value="LESS_EQUAL">on or before</option>
+            <option value="EQUAL">on</option>
+            <option value="GREATER_EQUAL">on or after</option>
+            <option value="GREATER_THAN">after</option>
+          </select>
+        </div>
+        <div className="col-sm-4">
+          <DatePicker
+            className="form-control"
+            id="modifier"
+            dateFormat="DD-MM-YYYY"
+            value={this.state.modifier}
+            name="modifier"
+            onChange={this.handleDateChange('modifier')}
+          />
+        </div>
+      </div>
     );
   }
 
@@ -263,23 +263,23 @@ export default class ObsFilter extends React.Component {
   whatValue() { 
     const { answers } = this.props.concept;
     const option = (answer) => (
-            <option key={answer.uuid} value={answer.uuid} > {answer.display} </option >
-        );
-    return( 
+      <option key={answer.uuid} value={answer.uuid} > {answer.display} </option >
+    );
+    return(
       answers.length > 0  ?
-      <div className="form-group col-sm-12" >
+        <div className="form-group col-sm-12">
           <label className="col-sm-4 control-label" >(optional) What value?</label>
           <div className="col-sm-4">
-              <select className="form-control"
-                id="modifier" 
-                value={this.state.modifier}
-                onChange={this.handleFormChange}
-                name="modifier">
-                <option value="">select a value</option>
-                {answers.map(option)}
-              </select>
+            <select className="form-control"
+              id="modifier" 
+              value={this.state.modifier}
+              onChange={this.handleFormChange}
+              name="modifier">
+              <option value="">select a value</option>
+              {answers.map(option)}
+            </select>
           </div>
-      </div> : ""
+        </div> : ""
     );
   }
 
@@ -287,17 +287,17 @@ export default class ObsFilter extends React.Component {
   // BIT(Boolean)
   secondFieldBoolean() {
     return (
-      <div className="form-group "> 
+      <div className="form-group"> 
         <label  className="col-sm-4 control-label">(optional) What values?</label>
         <div className="col-sm-6" name="modifier">
-            <select className="form-control" 
-                name="modifier"
-                value={this.state.modifier}
-                onChange={this.handleFormChange}>
-                <option value="">select a value</option>
-                <option value="true"> true</option>
-                <option value="false">false</option>
-            </select> 
+          <select className="form-control" 
+            name="modifier"
+            value={this.state.modifier}
+            onChange={this.handleFormChange}>
+            <option value="">select a value</option>
+            <option value="true"> true</option>
+            <option value="false">false</option>
+          </select> 
         </div>
       </div>
     );
@@ -309,14 +309,14 @@ export default class ObsFilter extends React.Component {
       <div>
         <div className="form-group">
           <div className="col-sm-6 col-sm-offset-3">
-              <select className="form-control" 
-                id="timeModifier"
-                name="timeModifier"
-                value={this.state.timeModifier}
-                onChange={this.handleFormChange}>
-                <option value="ANY">Patients whose observation has value {name } </option>
-                <option value="NO">Patients whose observation dose not have value { name } </option>
-              </select>
+            <select className="form-control" 
+              id="timeModifier"
+              name="timeModifier"
+              value={this.state.timeModifier}
+              onChange={this.handleFormChange}>
+              <option value="ANY">Patients whose observation has value {name } </option>
+              <option value="NO">Patients whose observation dose not have value { name } </option>
+            </select>
           </div>
         </div>
       </div>
@@ -327,39 +327,44 @@ export default class ObsFilter extends React.Component {
   endForm() {
     return (
       <div className="col-sm-12">
-          <div className="form-group col-sm-12">
-              <label className="col-sm-3 control-label">Date Range? Since:</label>
-              <div className="col-sm-3">
-                  <DatePicker
-                      className="form-control"
-                      id="onOrBefore"
-                      dateFormat="DD-MM-YYYY"
-                      value={this.state.onOrBefore}
-                      onChange={this.handleDateChange('onOrBefore')}
-                  />
-              </div>
-              <label className="col-sm-2 control-label">and/or Until:</label>
-              <div className="col-sm-3">
-                  <DatePicker
-                      className="form-control"
-                      id="onOrAfter"
-                      dateFormat="DD-MM-YYYY"
-                      value={this.state.onOrAfter}
-                      onChange={this.handleDateChange('onOrAfter')}
-                  />
-              </div>
-              <h5 className="col-sm-1">Optional</h5>
+        <div className="form-group col-sm-12">
+          <label className="col-sm-3 control-label">Date Range? Since:</label>
+          <div className="col-sm-3">
+            <DatePicker
+              className="form-control"
+              id="onOrBefore"
+              dateFormat="DD-MM-YYYY"
+              value={this.state.onOrBefore}
+              onChange={this.handleDateChange('onOrBefore')}
+            />
           </div>
-          <div className="form-group">
-              <div className="col-sm-offset-3 col-sm-6">
-                  <button type="submit" className="btn btn-success" >Search</button>
-                  <button
-                    type="reset"
-                    className="btn btn-default cancelBtn"
-                    onClick={this.handleReset}
-                  >Reset</button>
-              </div>
+          <label className="col-sm-2 control-label">and/or Until:</label>
+          <div className="col-sm-3">
+            <DatePicker
+              className="form-control"
+              id="onOrAfter"
+              dateFormat="DD-MM-YYYY"
+              value={this.state.onOrAfter}
+              onChange={this.handleDateChange('onOrAfter')}
+            />
           </div>
+          <h5 className="col-sm-1">Optional</h5>
+        </div>
+        <div className="form-group">
+          <div className="col-sm-offset-3 col-sm-6">
+            <button
+              type="submit"
+              className="btn btn-success"
+              onClick={this.handleSubmit && this.handleReset}
+            >Search
+            </button>
+            <button
+              type="reset"
+              className="btn btn-default cancelBtn"
+              onClick={this.handleReset}
+            >Reset</button>
+          </div>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
# JIRA TICKET NAME:
CB-163 - [Form resets when the Search button is clicked](https://issues.openmrs.org/browse/CB-163)

## SUMMARY:
Currently, when a user (1) does a query about obs, (2) does a query about encounters, (3) views the results of the obs query, (4) clicks Back.
They see a form with the values entered in their previous search, which can be quite confusing.

After bug fix:
After clicking on 'Search', The data should be saved and the query reset. 
Thus, a user should see an empty form upon clicking the ‘Search’ button. This means that even after viewing results, a user should view a reset form on clicking 'Back'.
