### PR TITLE
[CB-163] Form resets when the Search button is clicked

### DIFF
--- a/app/js/components/tabs/tabcomponents/observationComponent.jsx
+++ b/app/js/components/tabs/tabcomponents/observationComponent.jsx
@@ -343,33 +343,19 @@ export default class ObsFilter extends React.Component {
               onChange={this.handleDateChange('onOrBefore')}
             />
           </div>
-          <label className="col-sm-2 control-label">and/or Until:</label>
-          <div className="col-sm-3">
-            <DatePicker
-              className="form-control"
-              id="onOrAfter"
-              dateFormat="DD-MM-YYYY"
-              value={this.state.onOrAfter}
-              onChange={this.handleDateChange('onOrAfter')}
-            />
-          </div>
-          <h5 className="col-sm-1">Optional</h5>
-        </div>
         <div className="form-group">
           <div className="col-sm-offset-3 col-sm-6">
             <button
-              type="submit"
+              type="submit" 
               className="btn btn-success"
-            >
-            Search
+              onClick={this.handleSubmit && this.handleReset}
+            >Search
             </button>
             <button
               type="reset"
               className="btn btn-default cancelBtn"
               onClick={this.handleReset}
-            >
-            Reset
-            </button>
+            >Reset</button>
           </div>
         </div>
       </div>

--- a/app/js/components/tabs/tabcomponents/observationComponent.jsx
+++ b/app/js/components/tabs/tabcomponents/observationComponent.jsx
@@ -355,21 +355,19 @@ export default class ObsFilter extends React.Component {
           </div>
           <h5 className="col-sm-1">Optional</h5>
         </div>
-        <div className="form-group">
+         <div className="form-group">
           <div className="col-sm-offset-3 col-sm-6">
             <button
-              type="submit"
+              type="submit" 
               className="btn btn-success"
-            >
-            Search
+              onClick={this.handleSubmit && this.handleReset}
+            >Search
             </button>
             <button
               type="reset"
               className="btn btn-default cancelBtn"
               onClick={this.handleReset}
-            >
-            Reset
-            </button>
+            >Reset</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
# JIRA TICKET NAME:
CB-163 - [Form resets when the Search button is clicked](https://issues.openmrs.org/browse/CB-163)

## SUMMARY:
Currently, when a user does a query about obs and enters search, the data entered in the query remains on the form. In that, they see a form with the values entered in their previous search, which can be quite confusing.

After bug fix:
After clicking on search, The data should be saved and the query reset. Thus, a user should see an empty form upon clicking the ‘Search’ button on the Concept/Observation component. This means that even after viewing results, a user should view a reset form on clicking 'Back'.
