### PR TITLE
CB-162: Add ‘Clear Search History’ option

### DIFF
--- a/app/css/cohortbuilder.css
+++ b/app/css/cohortbuilder.css
@@ -228,3 +228,7 @@ a:hover {
 .Select.Select--multi .Select-menu-outer {
     z-index: 5;
 }
+
+.no-border-radius {
+    border-radius: 0px;
+}

--- a/app/js/components/page/pageComponent.jsx
+++ b/app/js/components/page/pageComponent.jsx
@@ -21,6 +21,7 @@ class PageComponent extends Component{
     };
     this.addToHistory = this.addToHistory.bind(this);
     this.deleteHistory = this.deleteHistory.bind(this);
+    this.clearSearchHistory = this.clearSearchHistory.bind(this);
   }
 
   componentDidMount() {
@@ -54,6 +55,19 @@ class PageComponent extends Component{
   }
 
   /**
+   * Clear all saved searches by deleting them from session storage
+   * @return {void} void
+   * @memberof SearchHistoryComponent
+   */
+  clearSearchHistory() {
+    const confirmDelete = confirm('Are you sure you want to delete your saved Search History?');
+    if(confirmDelete) {
+      window.sessionStorage.removeItem('openmrsHistory');
+      this.updateStateHistory([]);
+    }
+  }
+
+  /**
    * Function to update history property in the component state
    * @param {Array} history - new array containing history to be set in the component state
    * @return {undefined} - returns undefined
@@ -65,13 +79,14 @@ class PageComponent extends Component{
   render(){
     return(
       <div id="body-wrapper" className="page-wrapper">
-          <TabsComponent 
-              addToHistory={this.addToHistory} 
-              getHistory = {this.props.getHistory} />
-          <SearchHistoryTab 
-              history={this.state.history} 
-              deleteHistory={this.deleteHistory} 
-              getHistory = {this.props.getHistory} />
+        <TabsComponent 
+          addToHistory={this.addToHistory} 
+          getHistory = {this.props.getHistory} />
+        <SearchHistoryTab 
+          history={this.state.history} 
+          deleteHistory={this.deleteHistory} 
+          getHistory = {this.props.getHistory} 
+          clearSearchHistory={this.clearSearchHistory} />
       </div>
     );
   }

--- a/app/js/components/searchHistory/searchHistoryComponent.jsx
+++ b/app/js/components/searchHistory/searchHistoryComponent.jsx
@@ -35,6 +35,7 @@ class SearchHistoryComponent extends Component {
     this.navigatePage = this.navigatePage.bind(this);
     this.historyItemData = this.historyItemData.bind(this);
     this.downloadCSV = this.downloadCSV.bind(this);
+    this.displayClearSearchButton = this.displayClearSearchButton.bind(this);
   }
 
   navigatePage(event) {
@@ -136,6 +137,24 @@ class SearchHistoryComponent extends Component {
     };
   }
 
+  /**
+   * checks if there is a saved search history and displays the clear 
+   * search button
+   * @return {void} a button element
+   * @memberof SearchHistoryComponent
+   */
+  displayClearSearchButton() {
+    if(window.sessionStorage.getItem('openmrsHistory')) {
+      return (
+        <button
+          className="btn btn-sm btn-success pull-right no-border-radius"
+          onClick={this.props.clearSearchHistory} >
+          Clear Search History
+        </button>
+      );
+    }
+  }
+
   render(){
     const { history } = this.props;
     return (
@@ -154,47 +173,50 @@ class SearchHistoryComponent extends Component {
           history={this.props.history}
         />
         <div className="col-sm-12 section">
-            <h4>Search History</h4>
-            <div className="result-window">
-                {
-                    (history.length > 0) ?
-                      <table className="table table-striped">
-                        <thead>
-                            <tr>
-                                <th className="table-header">#</th>
-                                <th>Query</th>
-                                <th>Query Definition Options</th>
-                                <th>Results</th>
-                                <th>Cohort Definition Options</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {
-                                history.map((eachResult, index) => 
-                                (<tr key={shortId.generate()}>
-                                    <th scope="row">{this.props.history.length - index}</th>
-                                    <td>
-                                        {eachResult.description}
-                                    </td>
-                                    <td> 
-                                        <a className="link" title="Save Query Definition" aria-hidden="true"  data-toggle="modal" data-target="#myModal" onClick={this.setSaveSearch(index)}>Save</a>
-                                        <a className="link" title={`Delete ${eachResult.description}`} onClick={this.delete(index)} aria-hidden="true">Delete</a>
-                                    </td>
-                                    <td>
-                                        <a className="link" onClick={this.viewResult(index, eachResult.description)} title={`View ${eachResult.description}`} aria-hidden="true">{eachResult.patients ? `${eachResult.patients.length} result(s)`: 0}</a>
-                                    </td>
-                                    <td>
-                                        <a className="link" onClick={this.downloadCSV(index, eachResult.description)} title={`Dowload ${eachResult.description}`} aria-hidden="true">Download</a>
-                                        <a className="link" title="Save Cohorts" aria-hidden="true"  data-toggle="modal" data-target="#myCohort" onClick={this.setSaveCohort(eachResult.description, index)}>Save</a>
-                                    </td>
-                                </tr>)
-                                )
-                            }
-                        </tbody>
-                    </table>
-                        : ""
-                }
-            </div>
+          <div className="clearfix">
+            <h4 className="pull-left">Search History</h4>
+            { this.displayClearSearchButton() }
+          </div>
+          <div className="result-window">
+            {
+              (history.length > 0) ?
+                <table className="table table-striped">
+                  <thead>
+                    <tr>
+                      <th className="table-header">#</th>
+                      <th>Query</th>
+                      <th>Query Definition Options</th>
+                      <th>Results</th>
+                      <th>Cohort Definition Options</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {
+                      history.map((eachResult, index) => 
+                        (<tr key={shortId.generate()}>
+                          <th scope="row">{this.props.history.length - index}</th>
+                          <td>
+                            {eachResult.description}
+                          </td>
+                          <td> 
+                            <a className="link" title="Save Query Definition" aria-hidden="true"  data-toggle="modal" data-target="#myModal" onClick={this.setSaveSearch(index)}>Save</a>
+                            <a className="link" title={`Delete ${eachResult.description}`} onClick={this.delete(index)} aria-hidden="true">Delete</a>
+                          </td>
+                          <td>
+                            <a className="link" onClick={this.viewResult(index, eachResult.description)} title={`View ${eachResult.description}`} aria-hidden="true">{eachResult.patients ? `${eachResult.patients.length} result(s)`: 0}</a>
+                          </td>
+                          <td>
+                            <a className="link" onClick={this.downloadCSV(index, eachResult.description)} title={`Dowload ${eachResult.description}`} aria-hidden="true">Download</a>
+                            <a className="link" title="Save Cohorts" aria-hidden="true"  data-toggle="modal" data-target="#myCohort" onClick={this.setSaveCohort(eachResult.description, index)}>Save</a>
+                          </td>
+                        </tr>)
+                      )
+                    }
+                  </tbody>
+                </table>
+                : ""
+            }
+          </div>
         </div>
       </div>
     );
@@ -207,7 +229,8 @@ SearchHistoryComponent.propTypes = {
   saveSearch: PropTypes.func,
   error: PropTypes.string,
   loading: PropTypes.bool.isRequired,
-  setHistory: PropTypes.func
+  setHistory: PropTypes.func,
+  clearSearchHistory: PropTypes.func,
 };
 
 export default SearchHistoryComponent;

--- a/app/js/components/searchHistory/searchHistoryTab.jsx
+++ b/app/js/components/searchHistory/searchHistoryTab.jsx
@@ -93,13 +93,14 @@ class  SearchHistoryTab  extends Component {
   render() {
     return (
       <div className="section">
-          <SearchHistory 
-            history={this.props.history} 
-            deleteHistory={this.props.deleteHistory} 
-            saveSearch={this.saveSearch}
-            error={this.state.error}
-            loading={this.state.loading}
-            getHistory = {this.props.getHistory} />
+        <SearchHistory 
+          history={this.props.history} 
+          deleteHistory={this.props.deleteHistory} 
+          saveSearch={this.saveSearch}
+          error={this.state.error}
+          loading={this.state.loading}
+          getHistory = {this.props.getHistory}
+          clearSearchHistory={this.props.clearSearchHistory} />
       </div>
     );
   }
@@ -108,7 +109,8 @@ class  SearchHistoryTab  extends Component {
 SearchHistoryTab.propTypes = {
   history: PropTypes.array.isRequired,
   deleteHistory: PropTypes.func.isRequired,
-  getHistory: PropTypes.func
+  getHistory: PropTypes.func,
+  clearSearchHistory: PropTypes.func,
 };
 
 export default SearchHistoryTab;

--- a/tests/searchHistoryComponent.test.jsx
+++ b/tests/searchHistoryComponent.test.jsx
@@ -23,8 +23,8 @@ describe('<SearchHistoryComponent />', () => {
     });
 
     it('should contain the correct elements', () => {
-        const wrapper = shallow(<SearchHistoryComponent history={[]} deleteHistory={() => ({})} loading={false} />);
-        expect(wrapper.find("div")).to.have.length(3);
+        const wrapper = shallow(<SearchHistoryComponent history={[]} deleteHistory={() => ({})} loading={false} clearSearchHistory={() => ({})} />);
+        expect(wrapper.find("div")).to.have.length(4);
         expect(wrapper.find("h4")).to.have.length(1);
     });
 

--- a/tests/tabsComponent.test.jsx
+++ b/tests/tabsComponent.test.jsx
@@ -18,6 +18,17 @@ import TabContentComponent from '../app/js/components/tabs/tabContentComponent';
 
 import Components from '../app/js/components/tabs/tabcomponents';
 
+// Mock Session Storage
+const sessionStorageStub = () => {
+  return {
+    getItem: sinon.stub(),
+    removeItem: sinon.stub(),
+  };
+};
+
+// replace window.sessionStorage with our mock
+window.sessionStorage = sessionStorageStub();
+
 const tabs = [
     {active: true, name: 'Concept / Observation', divId: 'concept', component: Components.ConceptComponent,  },
     {active: false, name: 'Patient Attributes', divId: 'patient', component: Components.PatientComponent },


### PR DESCRIPTION
# JIRA TICKET NAME:
[CB-162: Add ‘Clear Search History’ option, to enable user to toggle between retrieving their past search history, or starting their search on a clean slate, when they log in again.](https://issues.openmrs.org/browse/CB-162)

## SUMMARY:
This PR makes it possible for users to clear their saved search history. A "Clear Search History" button is displayed when there are saved searches. Clicking on this button will delete the search history
