### PR TITLE
[CB-168] Reset form when user clicks ‘Search’ , Patient Attributes

### DIFF
--- a/app/js/components/tabs/tabcomponents/patientComponent.jsx
+++ b/app/js/components/tabs/tabcomponents/patientComponent.jsx
@@ -131,6 +131,7 @@ class PatientComponent extends Component {
         searchParameters, this.getSearchByDemographicsDescription()
       );
     }
+    this.resetSearchByDemographics();
   }
 
   /**
@@ -248,6 +249,7 @@ class PatientComponent extends Component {
     this.performSearch(
       searchParameters, this.getSearchByAttributesDescription()
     );
+    this.resetSearchByAttributes();
   }
 
   navigatePage(event) {
@@ -368,7 +370,6 @@ class PatientComponent extends Component {
    * @return {undefined}
    */
   resetSearchByDemographics(event) {
-    event.preventDefault();
     this.setState({
       startDate: '',
       endDate: '',


### PR DESCRIPTION
# JIRA TICKET NAME:
CB-168 - [Reset form when user clicks ‘Search’ , Patient Attributes](https://issues.openmrs.org/browse/CB-168)

## SUMMARY:
Currently on the Patient Attributes, when you enter parameters on the search form, the entered values remain unchanged in the various fields.

**After bug fix**, when a user clicks on 'Search', the query form should be reset, and the results of the search should be visible in the Search History.  