### PR TITLE
CB-160: query description does not specify constraints applied to a query in search history

### DIFF
--- a/app/js/components/tabs/tabcomponents/observationComponent.jsx
+++ b/app/js/components/tabs/tabcomponents/observationComponent.jsx
@@ -13,6 +13,7 @@ import DatePicker from "react-bootstrap-date-picker";
 import shortid from 'shortid';
 import { JSONHelper } from '../../../helpers/jsonHelper';
 import utility from '../../../utility';
+import { formatDate, queryDescriptionBuilder } from '../../../helpers/helpers';
 
 export default class ObsFilter extends React.Component {
 
@@ -88,14 +89,11 @@ export default class ObsFilter extends React.Component {
         value: key === 'modifier' && ['CWE', 'TS'].includes(hl7Abbrev)?  [ this.state[key] ] : this.state[key]
       }) : '';
     });
+
     const searchData = this.jsonHelper.composeJson(params);
-    let description = `Patients with observations whose question is ${name}`;
-    if (hl7Abbrev === 'ZZ' && this.state.timeModifier === 'ANY') {
-      description = `Patients whose observation has value ${name}`;
-    }
-    if (hl7Abbrev === 'ZZ' && this.state.timeModifier === 'NO') {
-      description = `Patients whose observation dose not have value ${name}`;
-    }
+
+    const description = queryDescriptionBuilder(this.state, name);
+
     this.props.search(searchData, description)
       .then((data) => {
         if (JSON.stringify(data.rows) === JSON.stringify([])) {
@@ -210,6 +208,7 @@ export default class ObsFilter extends React.Component {
           <select
             className="form-control"
             name="operator1"
+            id="operator1"
             onChange={this.handleFormChange}
             value={this.state.operator1}>
             <option value="LESS_THAN">&lt;</option>
@@ -270,7 +269,7 @@ export default class ObsFilter extends React.Component {
   whatValue() { 
     const { answers } = this.props.concept;
     const option = (answer) => (
-      <option key={answer.uuid} value={answer.uuid} > {answer.display} </option >
+      <option key={answer.uuid} value={answer.uuid} > {answer.display} </option>
     );
     return( 
       answers.length > 0  ?
@@ -407,7 +406,7 @@ export default class ObsFilter extends React.Component {
     return str;
   }
 
-  render() {    
+  render() {
     return (
       <form className="form-horizontal col-sm-12" onSubmit={this.handleSubmit}>
       { this.renderForm() }

--- a/app/js/helpers/helpers.js
+++ b/app/js/helpers/helpers.js
@@ -1,0 +1,30 @@
+/**
+ * takes in a date string and returns it in the format dd/mm/yy
+ * @param {string} dateString date to be formatted
+ * @returns {string} date in the required format
+ */
+export const formatDate = (dateString) => {
+  const date = new Date(dateString);
+  const day = date.getDate();
+  const month = date.getMonth() + 1;
+  const year = date.getFullYear();
+  return `${day}/${month}/${year}`;
+};
+
+/**
+ * builds a query description based on query input 
+ * @param {object} state the current state
+ * @param {string} conceptName the concept name
+ * @returns {string} date in the required format
+ */
+export const queryDescriptionBuilder = (state, conceptName) => {
+  const { modifier, timeModifier, onOrAfter, onOrBefore } = state;
+  const operatorSelectInput = document.querySelector("#operator1");
+  const operatorText = operatorSelectInput.options[operatorSelectInput.selectedIndex].text;
+
+  const modifierDescription = modifier ? `${operatorText} ${modifier}` : '';
+  const onOrAfterDescription = onOrAfter ? `since ${formatDate(onOrAfter)}` : '';
+  const onOrBeforeDescription = onOrBefore ? `until ${formatDate(onOrBefore)}` : '';
+
+  return `Patients with ${timeModifier} ${conceptName} ${modifierDescription} ${onOrAfterDescription} ${onOrBeforeDescription}`.trim();
+};

--- a/tests/helpers/helpers.test.js
+++ b/tests/helpers/helpers.test.js
@@ -1,0 +1,57 @@
+import { formatDate, queryDescriptionBuilder } from '../../app/js/helpers/helpers';
+import { expect } from 'chai';
+
+const mockConceptName = 'Weight (Kg)';
+
+const mockState = {
+  "timeModifier": "ANY",
+  "question": "7fae062d-a5a4-4d02-885c-ddd60adde01f",
+  "operator1": "LESS_THAN",
+  "modifier": "",
+  "onOrBefore": "",
+  "onOrAfter": "",
+  "formToRender": ""
+}
+
+const mockStateWithMoreData = {
+  "timeModifier": "ANY",
+  "question": "7fae062d-a5a4-4d02-885c-ddd60adde01f",
+  "operator1": "LESS_THAN",
+  "modifier": "20",
+  "onOrBefore": "2017-11-01T11:00:00.000Z",
+  "onOrAfter": "2016-12-01T11:00:00.000Z",
+  "formToRender": ""
+}
+
+describe('formatDate function', () => {
+  it('should format date in the dd/mm/yy format', () => {
+    expect(formatDate('2017-01-01T11:00:00.000Z')).to.equal('1/1/2017');
+    expect(formatDate('2017-11-01T11:00:00.000Z')).to.equal('1/11/2017');
+  });
+  it('should return the correct formatted date', () => {
+    expect(formatDate('2017-01-01T11:00:00.000Z')).to.not.equal('1/1/2020');
+  });  
+});
+
+describe('queryDescriptionBuilder function', () => {
+  before(() => {
+    // Create a mock Select element with options before running the tests
+    const mockSelectElement = document.createElement('select');
+    mockSelectElement.id = "operator1";
+    const mockSelectOption = document.createElement("option");
+    mockSelectOption.value = 'LESS_THAN'
+    mockSelectOption.text =  '<'
+    mockSelectElement.selectedIndex = 0;
+    mockSelectElement.appendChild(mockSelectOption);
+    document.body.appendChild(mockSelectElement);
+  })
+
+  it('should return only timeModifier and concept name if modifier is not provided', () => {
+    expect(queryDescriptionBuilder(mockState, mockConceptName))
+      .to.equal('Patients with ANY Weight (Kg)');
+  });
+  it('should return a properly formatted message when all data is provided', () => {
+    expect(queryDescriptionBuilder(mockStateWithMoreData, mockConceptName))
+      .to.equal('Patients with ANY Weight (Kg) < 20 since 1/12/2016 until 1/11/2017');
+  });
+});


### PR DESCRIPTION
# JIRA TICKET NAME:
[Concept/Observation -  On numeric concept ("Weight (kg)”), query description does not specify the constraints applied to a query in search history.](https://issues.openmrs.org/browse/CB-160)

## SUMMARY:
This PR ensures that when a search query is done, there's a description in the search history that contains the search parameters/constraints applied