### PR TITLE
[CB-166] Results link shows table and navigates back to query form

### DIFF
--- a/app/js/components/App.jsx
+++ b/app/js/components/App.jsx
@@ -24,7 +24,6 @@ class App extends Component {
       table: 'none'
     };
     this.getHistory = this.getHistory.bind(this);
-    this.setHistory = this.setHistory.bind(this);
     this.back = this.back.bind(this);
   }
 
@@ -35,17 +34,12 @@ class App extends Component {
     });
   }
 
-  setHistory(data) {
-    this.setState({ 
-      history : data.rows || data.patients
-    });
-  }
-
   getHistory(data, description = "") {
     this.setState({ 
       description: description || data.searchDescription,
-      display: 'block',
-      table: 'none'
+      history : data.rows || data.patients,
+      display: 'none',
+      table: 'block'
     });
   }
  

--- a/app/js/components/searchHistory/searchHistoryComponent.jsx
+++ b/app/js/components/searchHistory/searchHistoryComponent.jsx
@@ -54,7 +54,7 @@ class SearchHistoryComponent extends Component {
     return (event) => {
       let allPatients = [];
       event.preventDefault();
-      this.props.setHistory(this.props.history[index], description);
+      this.props.getHistory(this.props.history[index], description);
       if(this.props.history[index].patients){
         allPatients = this.props.history[index].patients;
       }else{
@@ -229,7 +229,7 @@ SearchHistoryComponent.propTypes = {
   saveSearch: PropTypes.func,
   error: PropTypes.string,
   loading: PropTypes.bool.isRequired,
-  setHistory: PropTypes.func,
+  getHistory: PropTypes.func,
   clearSearchHistory: PropTypes.func,
 };
 

--- a/app/js/components/tabs/tabcomponents/compositionComponent.jsx
+++ b/app/js/components/tabs/tabcomponents/compositionComponent.jsx
@@ -90,7 +90,6 @@ class CompositionComponent extends Component {
           } else {
             utility.notifications('success', 'Search completed successfully');
           }
-          this.props.getHistory(data, compositionQuery.label);
           this.props.addToHistory(compositionQuery.label, data.rows, compositionQuery.query);
         }
       });
@@ -247,7 +246,6 @@ class CompositionComponent extends Component {
 
 CompositionComponent.propTypes = {
   addToHistory: PropTypes.func.isRequired,
-  getHistory: PropTypes.func.isRequired
 };
 
 export default CompositionComponent;

--- a/app/js/components/tabs/tabcomponents/programmeComponent.jsx
+++ b/app/js/components/tabs/tabcomponents/programmeComponent.jsx
@@ -125,7 +125,6 @@ class ProgrammeComponent extends Component {
           utility.notifications('success', 'Search completed successfully');
         }
         this.props.addToHistory(label, res.rows, jsonQuery.query);
-        this.props.getHistory(res, label);
         this.resetFields();
       }
     }).catch(error => error);
@@ -550,7 +549,6 @@ ProgrammeComponent.propTypes = {
   fetchData: React.PropTypes.func.isRequired,
   search: React.PropTypes.func.isRequired,
   addToHistory: React.PropTypes.func.isRequired,
-  getHistory: React.PropTypes.func.isRequired
 };
 
 export default ProgrammeComponent;

--- a/app/js/components/tabs/tabsComponent.jsx
+++ b/app/js/components/tabs/tabsComponent.jsx
@@ -57,7 +57,6 @@ class TabsComponent extends Component {
           else{
             data.searchDescription = description || queryDetails.label;
             data.query = queryDetails.query;
-            getHistory(data, data.searchDescription);
             resolve(data);
           }
         }).catch(error => error);


### PR DESCRIPTION
# JIRA TICKET NAME:

CB-166 - [Results link shows table and navigates back to query form](https://issues.openmrs.org/browse/CB-166)

## SUMMARY:

Currently, after the results are added in a new row in the search history. The results table fails to appear after clicking on results.

**After bug fix,** a user should be able to access a details table of all the patient results found from the search, in a new page.