### PR TITLE
[CB-175] Results form features number of results

### DIFF
--- a/app/js/components/common/table.jsx
+++ b/app/js/components/common/table.jsx
@@ -64,6 +64,7 @@ class cohortTable  extends Component {
   }
 
   render() {
+    const resultsLength = this.state.searchHistory.length;
     return (
       <div className="table-window">
         <button
@@ -77,6 +78,7 @@ class cohortTable  extends Component {
         {this.state.toDisplay.length > 0 ?
           <div className="table">
             <h1 className="text-center">{this.state.description}</h1>
+            <h5 className="text-center">This search has {resultsLength} result(s)</h5>
             <table className="table table-striped" >
               <thead>
                 <tr>


### PR DESCRIPTION
# JIRA TICKET NAME:
CB-175 - [Results form features number of results
](https://issues.openmrs.org/browse/CB-175)

## SUMMARY:
**Currently,** when a user clicks on the results link, they view the results with a heading detailing only the filters applied to produce those results.

**On fix**, a user should be able to see how may results the search yielded on the result form.