### PR TITLE
[CB-190] Make page details explicit

### DIFF
--- a/app/js/components/common/navigate.jsx
+++ b/app/js/components/common/navigate.jsx
@@ -28,7 +28,7 @@ export  const Navigate = ({currentPage, totalPage, navigatePage}) => {
           </span> :
           null
       }
-      <span className="page-display-counter">{currentPage + " of " + totalPage}</span>
+      <span className="page-display-counter">{"Page " +currentPage + " of " + totalPage}</span>
     </div>
   );
 };


### PR DESCRIPTION
# JIRA TICKET NAME:
CB-190 - [Make page details explicit](https://issues.openmrs.org/browse/CB-190)

## SUMMARY:
**Currently,** when results are displayed, they feature a number range on the lower right side, without detailing what the numbers imply.

**After fix,** a user should be able to tell that it is the number of pages they may need to navigate in order to view all the results yielded by their search.
