### PR TITLE
[CB-183] Reset all fields on Search -Encounter tab

### DIFF
--- a/app/js/components/tabs/tabcomponents/encounterComponent.jsx
+++ b/app/js/components/tabs/tabcomponents/encounterComponent.jsx
@@ -439,7 +439,7 @@ class EncounterComponent extends Component {
                   pattern="[0-9]*" 
                   className="form-control" 
                   id="atLeastCount" 
-                  value={this.atLeastCount} 
+                  value={this.state.atLeastCount} 
                   onKeyDown={this.handleValidateCountInput} 
                   onChange={this.handleCountChange} 
                   onKeyPress={this.handleOnKeyPress}
@@ -453,7 +453,7 @@ class EncounterComponent extends Component {
                   type="number" 
                   className="form-control" 
                   id="atMostCount" 
-                  value={this.atMostCount} 
+                  value={this.state.atMostCount} 
                   onKeyDown={this.handleValidateCountInput} 
                   onChange={this.handleCountChange} 
                   onKeyPress={this.handleOnKeyPress}


### PR DESCRIPTION
# JIRA TICKET NAME:
CB-183 - [Reset all fields on Search -Encounter tab](https://issues.openmrs.org/browse/CB-183)

## SUMMARY:
**Currently**, when you hit 'Search' on the Encounter tab, the fields 'At least this many' and 'Up to  this many' do not reset alongside the other form values.
 
**After fix,** all the fields in the Encounter tab should be reset once the Search button is clicked on
