### PR TITLE
CB-194: Concept/Observation query with "Postpartum Hemorrhage" not working

### DIFF
--- a/app/js/components/tabs/tabcomponents/observationComponent.jsx
+++ b/app/js/components/tabs/tabcomponents/observationComponent.jsx
@@ -138,6 +138,7 @@ export default class ObsFilter extends React.Component {
             value={this.state.timeModifier}
             defaultValue="ANY"
             name="timeModifier"
+            id="timeModifier"
             onChange={this.handleFormChange}>
             <option value="ANY">Any</option>
             <option value="NO">None</option>
@@ -160,6 +161,7 @@ export default class ObsFilter extends React.Component {
           <select
             className="form-control"
             name="timeModifier"
+            id="timeModifier"
             value={this.state.timeModifier}
             defaultValue="ANY"
             onChange={this.handleFormChange}>
@@ -183,6 +185,7 @@ export default class ObsFilter extends React.Component {
           <select
             className="form-control"
             name="timeModifier"
+            id="timeModifier"
             defaultValue="ANY"
             onChange={this.handleFormChange}
             value={this.state.timeModifier}>

--- a/app/js/helpers/helpers.js
+++ b/app/js/helpers/helpers.js
@@ -30,8 +30,22 @@ export const queryDescriptionBuilder = (state, conceptName) => {
     : document.querySelector("#timeModifier");
 
   const operatorText = operatorSelectInput.options[operatorSelectInput.selectedIndex].text;
+  const modifierElement = document.querySelector("#modifier");
 
-  const modifierDescription = modifier ? `${operatorText} ${modifier}` : '';
+  const newModifier = (isNaN(modifier))
+    ? modifierElement.options[modifierElement.selectedIndex].text
+    : modifier;
+
+  let modifierDescription;
+
+  if (modifier && isNaN(modifier)) {
+    modifierDescription = `= ${newModifier}`;
+  } else if (modifier) {
+    modifierDescription = `${operatorText} ${newModifier}`;
+  } else {
+    modifierDescription = '';
+  }
+
   const onOrAfterDescription = onOrAfter ? `since ${formatDate(onOrAfter)}` : '';
   const onOrBeforeDescription = onOrBefore ? `until ${formatDate(onOrBefore)}` : '';
 


### PR DESCRIPTION
# JIRA TICKET NAME:
[Concept/Observation query with "Postpartum Hemorrhage", "Hemorrhage in early pregnancy" concept not working](https://issues.openmrs.org/browse/CB-194)

## SUMMARY:
This PR fixes the error of not being able to query "Postpartum Hemorrhage", "Hemorrhage in early pregnancy" concepts on the Cohort Builder

