### PR TITLE
[CB-211] Release Cohort Builder OWA version 1.0.0

### DIFF
--- a/app/manifest.webapp
+++ b/app/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "name": "CohortBuilder",
-  "description": "modern refresh of the OpenMRS Cohort Builder tool",
+  "name": "Cohort Builder",
+  "description": "Modern refresh of the OpenMRS Cohort Builder tool",
   "launch_path": "index.html",
   "icons": {
     "48": "/img/omrs-button.png"

--- a/bintray.json
+++ b/bintray.json
@@ -10,6 +10,6 @@
         "released": "2018-01-31"
     },
 
-    "files":[{"includePattern": "build/(.*\\.zip)", "uploadPattern": "$1"}],
+    "files":[{"includePattern": "./(.*\\.zip)", "uploadPattern": "$1"}],
     "publish": true
 }


### PR DESCRIPTION
# JIRA TICKET NAME:
[[CB-211] Release Cohort Builder OWA version 1.0.0](https://issues.openmrs.org/browse/CB-211)
## SUMMARY:
The current release of Cohort Builder is 1.0.0-beta.
The task is to release an updated version of the Cohort Builder OWA 1.0.0 using Github release tags